### PR TITLE
Reverted to default temperature handler

### DIFF
--- a/Consolidated Drivers/zwave-sensor/src/homeseer-leak/init.lua
+++ b/Consolidated Drivers/zwave-sensor/src/homeseer-leak/init.lua
@@ -14,7 +14,6 @@ local CC = require "st.zwave.CommandClass"
 local Battery = (require "st.zwave.CommandClass.Battery")({ version = 1 })
 local Basic = (require "st.zwave.CommandClass.Basic")({ version = 1 })
 local SensorBinary = (require "st.zwave.CommandClass.SensorBinary")({ version = 1 })
-local SensorMultilevel = (require "st.zwave.CommandClass.SensorMultilevel")({ version = 5 })
 local capabilities = require "st.capabilities"
 
 local ZWAVE_TEMP_LEAK_SENSOR_FINGERPRINTS = {
@@ -80,16 +79,6 @@ local function sensor_binary_report(driver, device, cmd)
   -- Ignore binary reports, as leak/temperature/tamper alerts all come via Notification Reports.
 end
 
-local function temperature_report(self, device, cmd)
-  if (cmd.args.sensor_type == SensorMultilevel.sensor_type.TEMPERATURE) then
-    local scale = 'C'
-    if (cmd.args.scale == SensorMultilevel.scale.temperature.FAHRENHEIT) then scale = 'F' end
-    local evt = capabilities.temperatureMeasurement.temperature({value = cmd.args.sensor_value, unit = scale})
-    evt.state_change = true
-    device:emit_event_for_endpoint(cmd.src_channel, evt)
-  end
-end
-
 --- @param self st.zwave.Driver
 --- @param device st.zwave.Device
 --- @param event table
@@ -121,9 +110,6 @@ local homeseer_leak = {
     },
     [CC.SENSOR_BINARY] = {
       [SensorBinary.REPORT] = sensor_binary_report,
-    },
-    [CC.SENSOR_MULTILEVEL] = {
-      [SensorMultilevel.REPORT] = temperature_report,
     },
   },
   lifecycle_handlers = {

--- a/Consolidated Drivers/zwave-sensor/src/homeseer-leak/init.lua
+++ b/Consolidated Drivers/zwave-sensor/src/homeseer-leak/init.lua
@@ -75,10 +75,6 @@ local function basic_set(driver, device, cmd)
   device.log.trace("basic_set() ignored")
 end
 
-local function sensor_binary_report(driver, device, cmd)
-  -- Ignore binary reports, as leak/temperature/tamper alerts all come via Notification Reports.
-end
-
 --- @param self st.zwave.Driver
 --- @param device st.zwave.Device
 --- @param event table
@@ -107,9 +103,6 @@ local homeseer_leak = {
   zwave_handlers = {
     [CC.BASIC] = {
       [Basic.SET] = basic_set,
-    },
-    [CC.SENSOR_BINARY] = {
-      [SensorBinary.REPORT] = sensor_binary_report,
     },
   },
   lifecycle_handlers = {


### PR DESCRIPTION
- The custom temperature handler was not needed, it was forcing an event change on all temperature reports.  We now just use the framework default handler.

Tested with the changes, works fine on the HS-LS100+.

Note that Fortrezz leak sensor can have the same change applied to its temperature_report handler.     state_change = true only should probably be used for button type events where something can be missed.