### PR TITLE
Add support for Ecolink Tilt Sensor 2

### DIFF
--- a/Consolidated Drivers/zwave-sensor/config.yml
+++ b/Consolidated Drivers/zwave-sensor/config.yml
@@ -1,5 +1,5 @@
 name: 'Z-Wave Sensor - philh30'
 packageKey: 'zwave-sensor-ph'
-description: "Supports HomeSeer HS-LS100+ leak sensor, Ecolink tilt sensor 2.5, and generic Zwave sensors."
+description: "Supports HomeSeer HS-LS100+ leak sensor, Ecolink tilt sensor 2 and 2.5, and generic Zwave sensors."
 permissions:
   zwave: {}

--- a/Consolidated Drivers/zwave-sensor/fingerprints.yml
+++ b/Consolidated Drivers/zwave-sensor/fingerprints.yml
@@ -17,12 +17,12 @@ zwaveManufacturer:
 #    productType: 0x0001
 #    productId: 0x0002
 #    deviceProfileName: contact-battery-tamperalert
-#  - id: 014A/0001/0003
-#    deviceLabel: Ecolink Open/Closed Sensor
-#    manufacturerId: 0x014A
-#    productType: 0x0001
-#    productId: 0x0003
-#    deviceProfileName: contact-battery-tamperalert        
+  - id: 014A/0001/0003   #TLT-ZWAVE2
+    deviceLabel: Ecolink Tilt Sensor 2
+    manufacturerId: 0x014A
+    productType: 0x0001
+    productId: 0x0003
+    deviceProfileName: ecolink-tilt-2
   - id: 014A/0004/0003   # TILT-ZWAVE2.5-ECO
     deviceLabel: Ecolink Tilt Sensor 2.5-ECO
     manufacturerId: 0x014A

--- a/Consolidated Drivers/zwave-sensor/profiles/ecolink-tilt-2.yml
+++ b/Consolidated Drivers/zwave-sensor/profiles/ecolink-tilt-2.yml
@@ -1,0 +1,45 @@
+name: ecolink-tilt-2
+components:
+- id: main
+  capabilities:
+  - id: contactSensor
+    version: 1
+  - id: tamperAlert
+    version: 1
+  - id: platemusic11009.deviceNetworkId
+    version: 1
+  - id: battery
+    version: 1
+  categories:
+  - name: GarageDoor
+preferences:
+  - name: "wakeUpInterval"
+    title: "Wake Up Interval"
+    description: "Default = <b>Every 12 hours</b>.<br>During wakeup the sensor can send battery updates and receive parameter changes."
+    required: true
+    preferenceType: enumeration
+    definition:
+      options:
+        3600:   "Every hour"
+        7200:   "Every 2 hours"
+        10800:  "Every 3 hours"
+        14400:  "Every 4 hours"
+        21600:  "Every 6 hours"
+        28800:  "Every 8 hours"
+        43200:  "Every 12 hours"   # default
+        86400:  "Every 24 hours"
+      default: 43200
+  - name: "batteryInterval"
+    title: "Battery Update Interval"
+    description: "Battery updates are requested during the wake up interval.<br>Default = <b>every wakeup</b>.<br>If disabled, the device will still send an alert when battery reaches critical."
+    required: true
+    preferenceType: enumeration
+    definition:
+      options:
+        0:      "Disabled"
+        1:      "Every wakeup"   # default
+        2:      "Every other wakeup"
+        3:      "Every 3rd wakeup"
+        4:      "Every 4th wakeup"
+        101:    "Once per day maximum"
+      default: 1

--- a/Consolidated Drivers/zwave-sensor/profiles/homeseer-leak-temp.yml
+++ b/Consolidated Drivers/zwave-sensor/profiles/homeseer-leak-temp.yml
@@ -33,16 +33,6 @@ preferences:
       minimum: 0
       maximum: 744
       default: 1
-  - name: "basicSetCommand"
-    title: "Basic Set Command"
-    description: "Enable Basic Set Command for reporting leak in addition to Notification Report.  Disabled by default."
-    required: true
-    preferenceType: enumeration
-    definition:
-      options:
-        0: "Disabled"
-        1: "Basic Set for leak notifications"
-      default: 0
   - name: "leakReportInterval"
     title: "Leak Report Interval Minutes"
     description: "Frequency of leak alarms once detected. In minutes between leak alarms.  Default = 5 minutes."
@@ -99,6 +89,13 @@ preferences:
         0: "Disabled"
         1: "Enabled"
       default: 1
+  - name: "basicSetCommand"
+    title: "Basic Set Command"
+    description: "Enable Basic Set Command for reporting leaks to association group 2.  Disabled by default."
+    required: true
+    preferenceType: boolean
+    definition:
+      default: false      
   - title: "Association Group 2 (Basic Set)"
     name: assocGroup2
     description: "Enter a comma delimited list of hex IDs. Flood Sensor will send Basic Set to associated nodes when Water leak detected. 5 node max."

--- a/Consolidated Drivers/zwave-sensor/profiles/homeseer-leak-temp.yml
+++ b/Consolidated Drivers/zwave-sensor/profiles/homeseer-leak-temp.yml
@@ -16,18 +16,14 @@ components:
     version: 1
   categories:
     - name: LeakSensor
-metadata:
-  deviceType: LeakSensor
-  ocfDeviceType: x.com.st.d.sensor.moisture
-  deviceTypeId: LeakSensor
 preferences:
   - name: "driverVersion"
     title: "Driver Version"
-    description: "<table style=\"font-size:100%;width:100%\"><tr><td>V0.90 2022-09-02.</td></tr><tr><td>Supports the HomeSeer HS-LS100+ Leak Sensor.</td></tr><tr><td>Temperature reporting enabled.</td></tr></table>"
+    description: "<table style=\"font-size:100%;width:100%\"><tr><td>V0.91 2022-09-02.</td></tr><tr><td>Supports the HomeSeer HS-LS100+ Leak Sensor.</td></tr><tr><td>Temperature reporting enabled.</td></tr></table>"
     required: false
-    preferenceType: string
+    preferenceType: boolean
     definition:
-      stringType: paragraph
+      default: false
   - name: "wakeUpInterval"
     title: "Wake Up / Battery Interval Hours"
     description: "Wake up interval in hours (0-744).<br>The sensor reports battery status during wakeup and can receive Settings updates.  Default = 1 hour."

--- a/Consolidated Drivers/zwave-sensor/profiles/homeseer-leak.yml
+++ b/Consolidated Drivers/zwave-sensor/profiles/homeseer-leak.yml
@@ -29,16 +29,6 @@ preferences:
       minimum: 0
       maximum: 744
       default: 1
-  - name: "basicSetCommand"
-    title: "Basic Set Command"
-    description: "Enable Basic Set Command for reporting leak in addition to Notification Report.  Disabled by default."
-    required: true
-    preferenceType: enumeration
-    definition:
-      options:
-        0: "Disabled"
-        1: "Basic Set for leak notifications"
-      default: 0
   - name: "leakReportInterval"
     title: "Leak Report Interval Minutes"
     description: "Frequency of leak alarms once detected. In minutes between leak alarms.  Default = 5 minutes."
@@ -95,6 +85,13 @@ preferences:
         0: "Disabled"
         1: "Enabled"
       default: 1
+  - name: "basicSetCommand"
+    title: "Basic Set Command"
+    description: "Enable Basic Set Command for reporting leaks to association group 2.  Disabled by default."
+    required: true
+    preferenceType: boolean
+    definition:
+      default: false
   - title: "Association Group 2 (Basic Set)"
     name: assocGroup2
     description: "Enter a comma delimited list of hex IDs. Flood Sensor will send Basic Set to associated nodes when Water leak detected. 5 node max."

--- a/Consolidated Drivers/zwave-sensor/profiles/homeseer-leak.yml
+++ b/Consolidated Drivers/zwave-sensor/profiles/homeseer-leak.yml
@@ -12,18 +12,14 @@ components:
     version: 1
   categories:
     - name: LeakSensor
-metadata:
-  deviceType: LeakSensor
-  ocfDeviceType: x.com.st.d.sensor.moisture
-  deviceTypeId: LeakSensor
 preferences:
   - name: "driverVersion"
     title: "Driver Version"
-    description: "<table style=\"font-size:100%;width:100%\"><tr><td>V0.90 2022-09-02.</td></tr><tr><td>Supports the HomeSeer HS-LS100+ Leak Sensor.</td></tr><tr><td>No temperature shown (temperature reporting not enabled.)</td></tr></table>"
+    description: "<table style=\"font-size:100%;width:100%\"><tr><td>V0.91 2022-09-02.</td></tr><tr><td>Supports the HomeSeer HS-LS100+ Leak Sensor.</td></tr><tr><td>Temperature reporting disabled.</td></tr></table>"
     required: false
-    preferenceType: string
+    preferenceType: boolean
     definition:
-      stringType: paragraph
+      default: false
   - name: "wakeUpInterval"
     title: "Wake Up / Battery Interval Hours"
     description: "Wake up interval in hours (0-744).  The sensor reports battery status during wakeup and can receive Settings updates. Default = 1 hour."

--- a/Consolidated Drivers/zwave-sensor/src/configurations.lua
+++ b/Consolidated Drivers/zwave-sensor/src/configurations.lua
@@ -345,7 +345,20 @@ local devices = {
     ASSOCIATION = {
       {grouping_identifier = 1}
     }
-  }
+  },
+  ECOLINK_TILT_SENSOR_2_5 = {
+    MATCHING_MATRIX = {
+      mfrs = 0x014A,
+      product_types = 0x0004,
+      product_ids = 0x0003
+    },
+    NOTIFICATION = {
+      -- Set the notification parameters for the device
+      { notification_type = Notification.notification_type.ACCESS_CONTROL, notification_status = Notification.notification_status.ON },    -- Enable notifications for tilt sensor
+      { notification_type = Notification.notification_type.HOME_SECURITY, notification_status = Notification.notification_status.ON  },    -- Enable notifications for tamper switch
+      { notification_type = Notification.notification_type.POWER_MANAGEMENT, notification_status = Notification.notification_status.ON },  -- Enable notifications for below 2.6V battery alerts
+    }
+  },
 }
 local configurations = {}
 

--- a/Consolidated Drivers/zwave-sensor/src/ecolink-tilt/init.lua
+++ b/Consolidated Drivers/zwave-sensor/src/ecolink-tilt/init.lua
@@ -175,13 +175,6 @@ local function eco_doConfigure(self, device, event, args)
     -- Call the topmost 'doConfigure' lifecycle hander to do the default work first
     call_parent_handler(self.lifecycle_handlers.doConfigure, self, device, event, args)
 
-    -- On the zwave plus version (2.5ECO), make sure some defaults are set on the device.
-    if device:is_cc_supported(cc.ZWAVEPLUS_INFO) then
-        -- Configure notifications.  These are enabled by default but just to be sure.
-        device:send(Notification:Set({ notification_type = Notification.notification_type.ACCESS_CONTROL, notification_status = Notification.notification_status.ON }))  -- Enable notifications for tilt sensor
-        device:send(Notification:Set({ notification_type = Notification.notification_type.HOME_SECURITY, notification_status = Notification.notification_status.ON  }))  -- Enable notifications for tamper switch
-        device:send(Notification:Set({ notification_type = Notification.notification_type.POWER_MANAGEMENT, notification_status = Notification.notification_status.ON }))  -- Enable notifications for below 2.6V battery alerts
-        end
     -- Force a battery update now
     getBatteryUpdate(device, true)
 end

--- a/Consolidated Drivers/zwave-sensor/src/ecolink-tilt/init.lua
+++ b/Consolidated Drivers/zwave-sensor/src/ecolink-tilt/init.lua
@@ -128,7 +128,10 @@ end
 --- @param device st.zwave.Device
 --- @param cmd st.zwave.CommandClass.WakeUp.Notification
 local function wakeup_notification(self, device, cmd)
-    device.log.trace("wakeup_notification()")
+    device.log.trace("wakeup_notification(ecolink-tilt)")
+
+    call_parent_handler(self.zwave_handlers[cc.WAKE_UP][WakeUp.NOTIFICATION], self, device, cmd)
+
     -- When the cover is restored (tamper switch closed), the device wakes up.  Assume tamper is clear.
     device:emit_event(capabilities.tamperAlert.tamper.clear())
 

--- a/Consolidated Drivers/zwave-sensor/src/ecolink-tilt/init.lua
+++ b/Consolidated Drivers/zwave-sensor/src/ecolink-tilt/init.lua
@@ -12,8 +12,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
--- Ecolink garage door tilt sensor
-
+-- Ecolink garage door tilt sensor TLT-ZWAVE2.5ECO (Zwave Plus)
 -- Wake up Interval
 -- Device defaults to 12 hour wake up interval.  This value is adjustable from 3600 seconds (1 hour) to 604800 seconds (1 week) in 200 second increments.
 -- It rounds down to the nearest 3600 + 200 second interval (entering 3605 == 3600, 3799 = 3600, 3805 = 3800, etc)
@@ -63,7 +62,8 @@ local cc = require "st.zwave.CommandClass"
 local LAST_BATTERY_REPORT_TIME = "lastBatteryReportTime"
 
 local ECOLINK_TILT_FINGERPRINTS = {
-    { mfr = 0x014A, prod = 0x0004, model = 0x0003 } -- Ecolink Tilt Sensor 2.5 (zwave plus)
+    { mfr = 0x014A, prod = 0x0001, model = 0x0003 }, -- Ecolink Tilt Sensor 2 (zwave)
+    { mfr = 0x014A, prod = 0x0004, model = 0x0003 }, -- Ecolink Tilt Sensor 2.5 (zwave plus)
 }
 
 local function can_handle_ecolink_tilt(opts, driver, device, ...)
@@ -82,7 +82,7 @@ local function call_parent_handler(handlers, self, device, event, args)
     for _, func in ipairs( handlers or {} ) do
         func(self, device, event, args)
     end
-  end
+end
 
 -- Request a battery update from the device.
 -- This should only be called when the radio is known to be listening
@@ -157,7 +157,9 @@ end
 --- @param device st.zwave.Device
 --- @param cmd st.zwave.CommandClass.SensorBinary.Report
 local function sensor_binary_report_handler(self, device, cmd)
-  if (cmd.args.sensor_type == SensorBinary.sensor_type.FIRST) then   -- Sends sensor type of 0xFF
+  -- The WAVE2 version sends a BINARY REPORT V1, which does not contain the sensor type.
+  -- The WAVE2.5 version sends a BINARY REPORT V2 which contains the sensor type "FIRST"
+  if (cmd.args.sensor_type == nil) or (cmd.args.sensor_type == SensorBinary.sensor_type.FIRST) then   -- Sends sensor type of 0xFF
     -- Change to a door/window sensor and call default handers
     cmd.args.sensor_type = SensorBinary.sensor_type.DOOR_WINDOW
     call_parent_handler(self.zwave_handlers[cc.SENSOR_BINARY][SensorBinary.REPORT], self, device, cmd)
@@ -173,11 +175,13 @@ local function eco_doConfigure(self, device, event, args)
     -- Call the topmost 'doConfigure' lifecycle hander to do the default work first
     call_parent_handler(self.lifecycle_handlers.doConfigure, self, device, event, args)
 
-    -- Configure notifications.  These are enabled by default but just to be sure.
-    device:send(Notification:Set({ notification_type = Notification.notification_type.ACCESS_CONTROL, notification_status = Notification.notification_status.ON }))  -- Enable notifications for tilt sensor
-    device:send(Notification:Set({ notification_type = Notification.notification_type.HOME_SECURITY, notification_status = Notification.notification_status.ON  }))  -- Enable notifications for tamper switch
-    device:send(Notification:Set({ notification_type = Notification.notification_type.POWER_MANAGEMENT, notification_status = Notification.notification_status.ON }))  -- Enable notifications for below 2.6V battery alerts
-
+    -- On the zwave plus version (2.5ECO), make sure some defaults are set on the device.
+    if device:is_cc_supported(cc.ZWAVEPLUS_INFO) then
+        -- Configure notifications.  These are enabled by default but just to be sure.
+        device:send(Notification:Set({ notification_type = Notification.notification_type.ACCESS_CONTROL, notification_status = Notification.notification_status.ON }))  -- Enable notifications for tilt sensor
+        device:send(Notification:Set({ notification_type = Notification.notification_type.HOME_SECURITY, notification_status = Notification.notification_status.ON  }))  -- Enable notifications for tamper switch
+        device:send(Notification:Set({ notification_type = Notification.notification_type.POWER_MANAGEMENT, notification_status = Notification.notification_status.ON }))  -- Enable notifications for below 2.6V battery alerts
+        end
     -- Force a battery update now
     getBatteryUpdate(device, true)
 end

--- a/Consolidated Drivers/zwave-sensor/src/init.lua
+++ b/Consolidated Drivers/zwave-sensor/src/init.lua
@@ -15,12 +15,16 @@
 local capabilities = require "st.capabilities"
 --- @type st.zwave.CommandClass
 local cc = require "st.zwave.CommandClass"
+---  @type st.Driver
+local Driver = require("st.driver")
 --- @type st.zwave.Driver
 local ZwaveDriver = require "st.zwave.driver"
 --- @type st.zwave.defaults
 local defaults = require "st.zwave.defaults"
 --- @type st.zwave.CommandClass.Association
 local Association = (require "st.zwave.CommandClass.Association")({ version=2 })
+--- @type st.zwave.CommandClass.WakeUp
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version=1 })
 
 local preferences = require "preferences"
 local configurations = require "configurations"
@@ -79,6 +83,9 @@ local function do_configure(driver, device)
     device:send(Association:Set({grouping_identifier = 1, node_ids ={driver.environment_info.hub_zwave_id}}))
     device:send(Association:Get({grouping_identifier = 1}))
   end
+
+  -- Mark this device as configured.  
+  device:set_field("device_configured", true, {persist = true} )
 end
 
 local initial_events_map = {
@@ -100,6 +107,21 @@ local function added_handler(self, device)
     end
   end
   updateNetworkId(self, device, device.device_network_id)
+end
+
+--- @param self st.zwave.Driver
+--- @param device st.zwave.Device
+local function driver_switched(self, device, event, args)
+  device.log.trace("driver_switched()")
+  -- Call the default handler 
+  Driver.default_capability_match_driverSwitched_handler(self, device, event, args)
+
+  if not device:is_cc_supported(cc.WAKE_UP) then
+    -- We're not a sleepy device, so run a doConfigure lifecycle event to configure the device now.
+    device.thread:queue_event(self.lifecycle_dispatcher.dispatch, self.lifecycle_dispatcher, self, device, "doConfigure")
+  else
+    device.log.info("Device is sleepy.  Will configure on next wakeup.")
+  end
 end
 
 local driver_template = {
@@ -125,19 +147,22 @@ local driver_template = {
     capabilities.voltageMeasurement,
     capabilities.energyMeter,
     capabilities.powerMeter,
-    capabilities.smokeDetector
+    capabilities.smokeDetector,
+    capabilities.refresh,
   },
   sub_drivers = {
+    require("sleepy-device"),  -- General support for any sleepy zwave devices
     require("ecolink-tilt"),
     require("zooz-motion-sensor"),
     require("fortrezz-leak"),
     require("homeseer-leak")
   },
   lifecycle_handlers = {
-    added       = added_handler,
-    init        = device_init,
-    infoChanged = info_changed,
-    doConfigure = do_configure
+    added          = added_handler,
+    init           = device_init,
+    infoChanged    = info_changed,
+    doConfigure    = do_configure,
+    driverSwitched = driver_switched,
   },
 }
 

--- a/Consolidated Drivers/zwave-sensor/src/init.lua
+++ b/Consolidated Drivers/zwave-sensor/src/init.lua
@@ -72,8 +72,8 @@ local function do_configure(driver, device)
   preferences.update_preferences(driver, device)
 
   -- Handle zwave plus lifeline associations
-  if device:is_cc_supported(cc.ZwaveplusInfo) and
-      device:is_cc_supported(cc.Association)  then
+  if device:is_cc_supported(cc.ZWAVEPLUS_INFO) and
+      device:is_cc_supported(cc.ASSOCIATION)  then
       -- Add us to lifeline
     device.log.debug("Adding to lifeline")
     device:send(Association:Set({grouping_identifier = 1, node_ids ={driver.environment_info.hub_zwave_id}}))

--- a/Consolidated Drivers/zwave-sensor/src/preferences.lua
+++ b/Consolidated Drivers/zwave-sensor/src/preferences.lua
@@ -101,7 +101,17 @@ local devices = {
       assocGroup2          = { type = 'assoc', group = 2, maxnodes = 5, addhub = false }
     }
   },
-  ECOLINK_TILT25 = {  -- Ecolink Tilt Sensor TILT-ZWAVE2.5-ECO
+  ECOLINK_TILT2 = {  -- Ecolink Tilt Sensor TILT-ZWAVE2 (zwave)
+    MATCHING_MATRIX = {
+      mfrs          = 0x014A,
+      product_types = 0x0001,
+      product_ids   = 0x0003
+    }, 
+    PARAMETERS = {
+      wakeUpInterval       = { type = 'wakeup' }, -- Wake up interval, preference is in seconds
+    }
+  },
+  ECOLINK_TILT25 = {  -- Ecolink Tilt Sensor TILT-ZWAVE2.5-ECO (zwave plus)
     MATCHING_MATRIX = {
       mfrs          = 0x014A,
       product_types = 0x0004,

--- a/Consolidated Drivers/zwave-sensor/src/sleepy-device/init.lua
+++ b/Consolidated Drivers/zwave-sensor/src/sleepy-device/init.lua
@@ -1,0 +1,60 @@
+-- Copyright 2022 philh30
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+--
+-- Support subdriver for zwave sleepy devices.
+-- 
+
+local WakeUp = (require "st.zwave.CommandClass.WakeUp")({ version = 1 })
+local cc = require "st.zwave.CommandClass"
+
+
+local function can_handle_sleepy_device(opts, driver, device, ...)
+    return device:is_cc_supported(cc.WAKE_UP)
+end
+
+local function call_parent_handler(handlers, self, device, event, args)
+    if type(handlers) == "function" then
+      handlers = { handlers }  -- wrap as table
+    end
+    for _, func in ipairs( handlers or {} ) do
+        func(self, device, event, args)
+    end
+end
+
+--- @param self st.zwave.Driver
+--- @param device st.zwave.Device
+--- @param cmd st.zwave.CommandClass.WakeUp.Notification
+local function wakeup_notification(self, device, cmd)
+  device.log.trace("wakeup_notification(sleepy-device)")
+
+  -- If we've not yet configured the device, execute it now.  This can be if we switched drivers.
+  if device:get_field("device_configured") ~= true then
+    device.log.debug("Configuration of device pending.")
+    call_parent_handler(self.lifecycle_handlers.doConfigure, self, device, "doConfigure")
+    -- device.thread:queue_event(self.lifecycle_dispatcher.dispatch, self.lifecycle_dispatcher, self, device, "doConfigure")
+  end
+end
+
+local sleepy_device = {
+    NAME = "Sleepy Device",
+    zwave_handlers = {
+        [cc.WAKE_UP] = {
+            [WakeUp.NOTIFICATION] = wakeup_notification,
+        },
+    },
+    can_handle = can_handle_sleepy_device,
+}
+
+return sleepy_device


### PR DESCRIPTION
- Added support for Tilt sensor 2 (zwave version)
- Fixed issue with lifeline association being sent incorrectly to zwave non plus devices.