### PR TITLE
Added support for Remotec ZFM-80 switch

### DIFF
--- a/Consolidated Drivers/zwave-switch/fingerprints.yml
+++ b/Consolidated Drivers/zwave-switch/fingerprints.yml
@@ -501,6 +501,12 @@ zwaveManufacturer:
     productType: 0x0003
     productId: 0x0006
     deviceProfileName: metering-switch
+  - id: "5254/8000/0002"
+    deviceLabel: Remotec Fixture Switch Module ZFM-80
+    manufacturerId: 0x5254
+    productType: 0x8000
+    productId: 0x0002
+    deviceProfileName: remotec-zfm80
 # Iris Range Extender
   - id: "0246/0001/0001"
     deviceLabel: Iris Repeater/Extender

--- a/Consolidated Drivers/zwave-switch/profiles/remotec-zfm80.yml
+++ b/Consolidated Drivers/zwave-switch/profiles/remotec-zfm80.yml
@@ -1,0 +1,32 @@
+name: remotec-zfm80
+components:
+- id: main
+  capabilities:
+  - id: switch
+    version: 1
+  - id: refresh
+    version: 1
+  categories:
+  - name: Switch
+preferences:
+  - title: "External Switch"
+    name: externalSwitchType
+    description: "Set external switch configuration"
+    required: true
+    preferenceType: enumeration
+    definition:
+      options:
+        0: "Disabled"
+        1: "Momentary - NO"
+        2: "Momentary - NC"
+        3: "Toggle - NO"
+        4: "Toggle - NC"
+      default: 3
+  - title: "Association Group 1"
+    name: assocGroup1
+    description: "Enter a comma delimited list of hex IDs to be turned on/off with the relay load (5 node max)"
+    required: true
+    preferenceType: string
+    definition:
+      stringType: text
+      default: ""

--- a/Consolidated Drivers/zwave-switch/src/preferences.lua
+++ b/Consolidated Drivers/zwave-switch/src/preferences.lua
@@ -312,6 +312,17 @@ local devices = {
       assocGroup4             = {type = 'assoc', group = 4, maxnodes = 5, addhub = false},
     }
   },
+  REMOTEC_ZFM80 = {
+    MATCHING_MATRIX = {
+      mfrs = 0x5254,
+      product_types = 0x8000,
+      product_ids = 0x0002,
+    },
+    PARAMETERS = {
+      externalSwitchType      = {type = 'config', parameter_number = 1, size = 1},
+      assocGroup1             = {type = 'assoc', group = 1, maxnodes = 5, addhub = false},
+    }
+  },
 }
 local preferences = {}
 


### PR DESCRIPTION
Adding basic support for the ZFM-80.   Should be fine with standard switch capability handlers.   Nothing special appears to be needed.

https://products.z-wavealliance.org/products/660
