### PR TITLE
Alternate exclusion for ge-*-assoc profiles

### DIFF
--- a/GE-Jasco/ge-zwave-switch/profiles/ge-dimmer-assoc.yml
+++ b/GE-Jasco/ge-zwave-switch/profiles/ge-dimmer-assoc.yml
@@ -38,6 +38,16 @@ preferences:
         0: "No"
         1: "Yes"
       default: 0
+  - title: "Exclusion Sequence"
+    name: excludeProtect
+    description: "Never accidentally remove a device with alternate exclusion"
+    required: true
+    preferenceType: enumeration
+    definition:
+      options:
+        0: "Press any button"
+        1: "Press ON twice and OFF twice"
+      default: 0
   - title: "Number of Dimming Steps (Z-Wave)"
     name: dimStepsZwave
     description: "Number of dimming steps when adjusted by z-wave"

--- a/GE-Jasco/ge-zwave-switch/profiles/ge-fan-assoc.yml
+++ b/GE-Jasco/ge-zwave-switch/profiles/ge-fan-assoc.yml
@@ -42,6 +42,16 @@ preferences:
         0: "No"
         1: "Yes"
       default: 0
+  - title: "Exclusion Sequence"
+    name: excludeProtect
+    description: "Never accidentally remove a device with alternate exclusion"
+    required: true
+    preferenceType: enumeration
+    definition:
+      options:
+        0: "Press any button"
+        1: "Press ON twice and OFF twice"
+      default: 0
   - title: "Association Group 2 - On/Off w/ Load"
     name: assocGroup2
     description: "Enter a comma delimited list of hex IDs to be turned on/off with the switch load (5 node max)"

--- a/GE-Jasco/ge-zwave-switch/profiles/ge-plugin-assoc.yml
+++ b/GE-Jasco/ge-zwave-switch/profiles/ge-plugin-assoc.yml
@@ -15,6 +15,16 @@ metadata:
   ocfDeviceType: oic.d.smartplug
   deviceTypeId: SmartPlug
 preferences:
+  - title: "Exclusion Sequence"
+    name: excludeProtect
+    description: "Never accidentally remove a device with alternate exclusion"
+    required: true
+    preferenceType: enumeration
+    definition:
+      options:
+        0: "Press any button"
+        1: "Press ON twice and OFF twice"
+      default: 0
   - title: "Association Group 2"
     name: assocGroup2
     description: "Enter a comma delimited list of hex IDs to be turned on/off with the switch load (5 node max)"

--- a/GE-Jasco/ge-zwave-switch/profiles/ge-switch-assoc.yml
+++ b/GE-Jasco/ge-zwave-switch/profiles/ge-switch-assoc.yml
@@ -36,6 +36,16 @@ preferences:
         0: "No"
         1: "Yes"
       default: 0
+  - title: "Exclusion Sequence"
+    name: excludeProtect
+    description: "Never accidentally remove a device with alternate exclusion"
+    required: true
+    preferenceType: enumeration
+    definition:
+      options:
+        0: "Press any button"
+        1: "Press ON twice and OFF twice"
+      default: 0
   - title: "Association Group 2"
     name: assocGroup2
     description: "Enter a comma delimited list of hex IDs to be turned on/off with the switch load (5 node max)"

--- a/GE-Jasco/ge-zwave-switch/src/preferences.lua
+++ b/GE-Jasco/ge-zwave-switch/src/preferences.lua
@@ -22,6 +22,7 @@ local GE_BASIC = {
     dimTimeManual   = {type = 'config', parameter_number = 10, size = 2},
     dimStepsAll     = {type = 'config', parameter_number = 11, size = 1},
     dimTimeAll      = {type = 'config', parameter_number = 12, size = 2},
+    excludeProtect  = {type = 'config', parameter_number = 19, size = 1},
     assocGroup2     = {type = 'assoc', group = 2, maxnodes = 5, addhub = false},
     assocGroup3     = {type = 'assoc', group = 3, maxnodes = 4, addhub = true},
   },


### PR DESCRIPTION
At least one device in each of the modified profiles has documented support for parameter 19 (alternate exclusion) on the latest firmware. Code was copied from the corresponding ge-*-scene profiles.