### PR TITLE
Disocvery should use async socket

### DIFF
--- a/Onkyo/onkyo-receiver/src/disco.lua
+++ b/Onkyo/onkyo-receiver/src/disco.lua
@@ -12,7 +12,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-local socket = require('socket')
+local socket = require('cosock.socket')
 local log = require('log')
 local config = require('config')
 


### PR DESCRIPTION
Updated require statement to refer to `cosock.socket` instead of `socket`.

This can cause significant issues when running discovery including, locking up the driver, causing a watch dog, inconsistent event ordering, loss of state, etc.

By updating this to be properly wrapped, we should see a more consistent operation during discovery.